### PR TITLE
chore(API-3): add pm2 ecosystem config file

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,34 @@
+
+module.exports = {
+  apps: [
+    {
+      // --- Configuración para la API ---
+      name: 'SecurityCam-API',       
+      script: './irvingchampo-apisecurity/src/index.ts', 
+      
+      // PM2 usará ts-node para ejecutar el archivo TypeScript directamente.
+      interpreter: 'node_modules/.bin/ts-node', 
+      
+
+      cwd: '/var/www/security-cam-project/irvingchampo-apisecurity',
+
+      watch: false, 
+      
+   
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+    {
+      // --- Configuración para el Servidor WebSocket ---
+      name: 'SecurityCam-WebSocket',  
+      script: './irvingchampo-ws-servidor-securitycam-/src/websocketServer.ts', 
+      interpreter: 'node_modules/.bin/ts-node',
+      cwd: '/var/www/security-cam-project/irvingchampo-ws-servidor-securitycam-',
+      watch: false,
+      env: {
+        NODE_ENV: 'production',
+      },
+    },
+  ],
+};


### PR DESCRIPTION
Este Pull Request resuelve el Issue #82  .

Se ha añadido un archivo `ecosystem.config.js` para la gestión centralizada de los servicios de Node.js (API y WebSocket) con PM2. Este archivo será utilizado por el script `post-deploy.sh` en el servidor para iniciar y gestionar las aplicaciones.